### PR TITLE
feat: improve target execution with web socket manipulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
         - name: Bandit
           run: bandit -r src/
         - name: pip-audit
-          run: pip-audit -r requirements.txt
+          run: pip-audit -r requirements.txt --ignore-vuln CVE-2026-25645

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+
+### Added
+- `WeniTarget` now accepts the optional `connect_ws_first` flag. When set to `True`,
+  the WebSocket connection is established before the POST request is sent, closing
+  the race window where the agent could broadcast a response before the listener was
+  ready. Defaults to `False` to preserve the legacy behavior.
+- `WeniTarget` now accepts the optional `accumulate_messages_window` (in seconds).
+  When greater than `0`, the target collects every broadcast message received during
+  a turn and waits this many seconds without a new message before returning the
+  concatenated response. Useful for agents that emit multiple messages per turn
+  (e.g. text + catalog). Defaults to `0`, which preserves the legacy behavior of
+  returning the first broadcast message.
+
 ## [0.4.1]
 
 - Fix broken module imports for `BedrockModelConfig` and `BedrockRequestHandler`.

--- a/docs/targets/weni.md
+++ b/docs/targets/weni.md
@@ -59,8 +59,10 @@ The required `websocket-client` package is automatically installed as a dependen
 ```yaml title="agenteval.yml"
 target:
   type: weni
-  # language: pt-BR  # Optional, defaults to pt-BR
-  # timeout: 30      # Optional, max seconds to wait for response
+  # language: pt-BR                       # Optional, defaults to pt-BR
+  # timeout: 480                          # Optional, max seconds to wait for response
+  # connect_ws_first: true                # Optional, recommended for multi-step tests
+  # accumulate_messages_window: 2.0       # Optional, recommended for agents that emit multiple messages per turn
   # Optionally provide credentials directly (not recommended):
   # weni_project_uuid: your-project-uuid
   # weni_bearer_token: your-bearer-token
@@ -106,10 +108,32 @@ language: en-US
 
 `timeout` *(integer; optional)*
 
-Maximum time in seconds to wait for the agent's response via WebSocket. Defaults to `30`.
+Maximum time in seconds to wait for the agent's response via WebSocket. Defaults to `480`.
 
 ```yaml
-timeout: 45
+timeout: 120
+```
+
+---
+
+`connect_ws_first` *(boolean; optional)*
+
+When `true`, establish the WebSocket connection before sending the prompt via HTTP POST. This closes a race window where the agent may broadcast a response before the listener is ready, which can cause the turn to wait the full `timeout` without receiving anything. Defaults to `false` to preserve the legacy ordering (POST first, then WS).
+
+Recommended for production usage, especially with multi-step tests.
+
+```yaml
+connect_ws_first: true
+```
+
+---
+
+`accumulate_messages_window` *(float; optional)*
+
+When greater than `0`, collect every broadcast message received during a turn and wait this many seconds without a new message before returning the concatenated response. Useful for agents that emit multiple messages per turn (for example, an introductory text followed by a catalog message). Defaults to `0`, which returns the first broadcast and discards anything that arrives afterwards.
+
+```yaml
+accumulate_messages_window: 2.0
 ```
 
 ## How It Works
@@ -239,6 +263,12 @@ weni-agenteval init
 - Check for any proxy configurations that might interfere with WebSocket connections
 - Verify the WebSocket endpoint URL is correct for your project
 
+**Test reports a partial or unrelated agent response**
+- The agent likely emitted more than one message per turn (for example, an introductory text followed by a catalog) and only the first one was captured. Set `accumulate_messages_window` to a small positive value (for example `2.0`) so the target collects every message before returning.
+
+**Turn hangs and times out even though the agent replied quickly**
+- The WebSocket may have been opened after the agent already broadcast its response, dropping the message. Set `connect_ws_first: true` so the listener is ready before the prompt is sent.
+
 ### Debug Logging
 
 To enable detailed logging for troubleshooting:
@@ -257,7 +287,8 @@ This will show detailed information about:
 ## Limitations
 
 - Each test case maintains its own conversation context through a unique contact identifier
-- The target waits for the `finalResponse` message type and ignores intermediate processing messages
+- By default the target returns the first broadcast received per turn; set `accumulate_messages_window` when the agent emits multiple messages per turn (e.g. text + catalog)
+- By default the WebSocket listener is opened after the prompt is sent; set `connect_ws_first: true` to avoid losing broadcasts that arrive before the listener is ready
 - Response time depends on the agent's complexity and the Weni platform's processing time
 
 ## See Also

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "weni-agenteval"
-version = "1.0.11"
+version = "1.1.0"
 description = "A generative AI-powered framework for testing virtual agents."
 authors = [{name = "Weni", email = "john.cordeiro@vtex.com"}]
 license = "Apache-2.0"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 from setuptools import find_packages
 
 DIST_NAME = "weni-agenteval"
-VERSION = "1.0.11"
+VERSION = "1.1.0"
 DESCRIPTION = "A generative AI-powered framework for testing virtual agents."
 AUTHOR = "Weni"
 EMAIL = "john.cordeiro@vtex.com"

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -96,7 +96,11 @@ def run(
     try:
         plan = Plan.load(plan_dir)
         plan.run(
-            verbose=verbose, num_threads=num_threads, work_dir=work_dir, filter=filter, watch=watch
+            verbose=verbose,
+            num_threads=num_threads,
+            work_dir=work_dir,
+            filter=filter,
+            watch=watch,
         )
 
     except TestFailureError:

--- a/src/agenteval/evaluators/bedrock_request/bedrock_request_handler.py
+++ b/src/agenteval/evaluators/bedrock_request/bedrock_request_handler.py
@@ -25,7 +25,7 @@ class BedrockRequestHandler:
     ) -> Dict:
         # Deep copy to avoid modifying the original config template
         request_body = copy.deepcopy(request_body)
-        
+
         if model_config.provider == ModelProvider.META:
             # Source for approach: https://www.llama.com/docs/model-cards-and-prompt-formats/llama3_3/
             request_body["prompt"] = (

--- a/src/agenteval/plan/plan.py
+++ b/src/agenteval/plan/plan.py
@@ -113,7 +113,9 @@ class Plan(BaseModel):
         # Check if target requires sequential execution
         target_type = self.config.get("target", {}).get("type")
         if target_type == "weni":
-            logger.info("Weni target detected - forcing single-threaded execution for WebSocket stability")
+            logger.info(
+                "Weni target detected - forcing single-threaded execution for WebSocket stability"
+            )
             return 1
 
         return (
@@ -151,7 +153,9 @@ class Plan(BaseModel):
             self._run_watch_mode()
         else:
             with Progress(transient=True) as self._progress:
-                self._tracker = self._progress.add_task("running...", total=self._num_tests)
+                self._tracker = self._progress.add_task(
+                    "running...", total=self._num_tests
+                )
                 self._run_concurrent()
 
         fail_count = self._num_tests - self._pass_count
@@ -179,7 +183,11 @@ class Plan(BaseModel):
             raise TestFailureError
 
     def _setup_run(
-        self, filter: Optional[str], work_dir: Optional[str], num_threads: Optional[int], watch: bool = False
+        self,
+        filter: Optional[str],
+        work_dir: Optional[str],
+        num_threads: Optional[int],
+        watch: bool = False,
     ):
         self._evaluator_factory = EvaluatorFactory(config=self.config["evaluator"])
         self._target_factory = TargetFactory(config=self.config["target"])
@@ -188,7 +196,9 @@ class Plan(BaseModel):
         self._num_tests = self._test_suite.num_tests
         self._work_dir = work_dir or os.getcwd()
         # In watch mode, force single-threaded execution for readable output
-        self._num_threads = 1 if watch else self._resolve_num_threads(self._num_tests, num_threads)
+        self._num_threads = (
+            1 if watch else self._resolve_num_threads(self._num_tests, num_threads)
+        )
         self._results = {test.name: None for test in self._test_suite}
         self._evaluator_input_token_counts = []
         self._evaluator_output_token_counts = []
@@ -211,15 +221,15 @@ class Plan(BaseModel):
     def _run_watch_mode(self):
         """Run tests in watch mode with real-time conversation display."""
         import click
-        
-        click.echo("\n" + "="*80)
+
+        click.echo("\n" + "=" * 80)
         click.echo(f"🔍 WATCH MODE: Running {self._num_tests} test(s) sequentially")
-        click.echo("="*80 + "\n")
-        
+        click.echo("=" * 80 + "\n")
+
         for i, test in enumerate(self._test_suite, 1):
             click.echo(f"📋 Test {i}/{self._num_tests}: {test.name}")
             click.echo("-" * 60)
-            
+
             # Create a custom evaluator that reports conversations in real-time
             target = self._target_factory.create()
             evaluator = self._evaluator_factory.create(
@@ -227,36 +237,38 @@ class Plan(BaseModel):
                 target=target,
                 work_dir=self._work_dir,
             )
-            
+
             # Monkey patch the evaluator to show conversations in real-time
             original_add_turn = evaluator.conversation.add_turn
             original_invoke_target = evaluator._invoke_target
-            
+
             def watch_invoke_target(user_input: str):
                 # Show user prompt immediately when sent
                 click.echo(f"\n👤 USER: {user_input}")
-                click.echo("🤖 AGENT: ", nl=False)  # Print "AGENT: " without newline, waiting for response
-                
+                click.echo(
+                    "🤖 AGENT: ", nl=False
+                )  # Print "AGENT: " without newline, waiting for response
+
                 # Call the original method to get agent response
                 agent_response = original_invoke_target(user_input)
-                
+
                 # Show the agent response
                 click.echo(agent_response)
                 click.echo()  # Add blank line for readability
-                
+
                 return agent_response
-            
+
             def watch_add_turn(user_message: str, agent_response: str):
                 # Call the original method (conversation display already handled in watch_invoke_target)
                 original_add_turn(user_message, agent_response)
-            
+
             # Apply the patches
             evaluator._invoke_target = watch_invoke_target
             evaluator.conversation.add_turn = watch_add_turn
-            
+
             # Run the test
             result = evaluator.run()
-            
+
             # Display test result
             if result.passed:
                 click.echo(f"✅ PASSED: {test.name}")
@@ -268,7 +280,7 @@ class Plan(BaseModel):
                 click.echo(f"   Result: {result.result}")
                 if result.reasoning:
                     click.echo(f"   Reasoning: {result.reasoning}")
-            
+
             # Update results
             with self._lock:
                 if result.passed is True:
@@ -276,13 +288,15 @@ class Plan(BaseModel):
                 self._results[test.name] = result
                 self._evaluator_input_token_counts.append(evaluator.input_token_count)
                 self._evaluator_output_token_counts.append(evaluator.output_token_count)
-            
+
             if i < self._num_tests:
-                click.echo("\n" + "="*80 + "\n")
-        
-        click.echo("\n" + "="*80)
-        click.echo(f"🏁 WATCH MODE COMPLETED: {self._pass_count}/{self._num_tests} tests passed")
-        click.echo("="*80 + "\n")
+                click.echo("\n" + "=" * 80 + "\n")
+
+        click.echo("\n" + "=" * 80)
+        click.echo(
+            f"🏁 WATCH MODE COMPLETED: {self._pass_count}/{self._num_tests} tests passed"
+        )
+        click.echo("=" * 80 + "\n")
 
     def _run_test(self, test):
         target = self._target_factory.create()

--- a/src/agenteval/targets/bedrock_agent/target.py
+++ b/src/agenteval/targets/bedrock_agent/target.py
@@ -18,7 +18,7 @@ class BedrockAgentTarget(Boto3Target):
         bedrock_agent_alias_id: str,
         bedrock_session_attributes: Optional[dict] = {},
         bedrock_prompt_session_attributes: Optional[dict] = {},
-        **kwargs
+        **kwargs,
     ):
         """Initialize the target.
 

--- a/src/agenteval/targets/q_business/target.py
+++ b/src/agenteval/targets/q_business/target.py
@@ -15,7 +15,7 @@ class QBusinessTarget(Boto3Target):
         self,
         q_business_application_id: str,
         q_business_user_id: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ):
         """
         Initialize the target.

--- a/src/agenteval/targets/sagemaker_endpoint/target.py
+++ b/src/agenteval/targets/sagemaker_endpoint/target.py
@@ -27,7 +27,7 @@ class SageMakerEndpointTarget(Boto3Target):
         target_variant: Optional[str] = None,
         target_container_hostname: Optional[str] = None,
         inference_component_name: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ):
         """
         Initialize the target.

--- a/src/agenteval/targets/weni/target.py
+++ b/src/agenteval/targets/weni/target.py
@@ -303,8 +303,8 @@ class WebSocketConnectionManager:
         try:
             if self.ws:
                 self.ws.close()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Error while closing WebSocket connection: {e}")
 
         # Only join thread if we're not calling from within the WebSocket thread itself
         if self.ws_thread and self.ws_thread.is_alive():

--- a/src/agenteval/targets/weni/target.py
+++ b/src/agenteval/targets/weni/target.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import os
-import uuid
-import time
 import logging
+import os
 import threading
+import time
+import uuid
 from typing import Optional
 
 import requests
@@ -49,13 +49,15 @@ class WebSocketConnectionManager:
         self._lock = threading.Lock()
         self._received_messages: list[str] = []
         self._last_message_time: float = 0.0
-        
+
     def connect(self) -> bool:
         """Establish WebSocket connection with retry logic."""
         for attempt in range(self.max_reconnect_attempts):
             try:
-                logger.debug(f"WebSocket connection attempt {attempt + 1}/{self.max_reconnect_attempts}")
-                
+                logger.debug(
+                    f"WebSocket connection attempt {attempt + 1}/{self.max_reconnect_attempts}"
+                )
+
                 self.ws = websocket.WebSocketApp(
                     self.endpoint,
                     on_open=self._on_open,
@@ -64,31 +66,35 @@ class WebSocketConnectionManager:
                     on_close=self._on_close,
                     on_ping=self._on_ping,
                     on_pong=self._on_pong,
-                    header=self.headers
+                    header=self.headers,
                 )
-                
+
                 # Run WebSocket in a separate thread
                 self.ws_thread = threading.Thread(target=self._run_with_ping)
                 self.ws_thread.daemon = True
                 self.ws_thread.start()
-                
+
                 # Wait a bit for connection to establish
                 time.sleep(1)
-                
+
                 if self.ws and not self.connection_lost:
                     logger.debug("WebSocket connection established successfully")
                     return True
-                    
+
             except Exception as e:
-                logger.warning(f"WebSocket connection attempt {attempt + 1} failed: {e}")
-                
+                logger.warning(
+                    f"WebSocket connection attempt {attempt + 1} failed: {e}"
+                )
+
             if attempt < self.max_reconnect_attempts - 1:
-                logger.debug(f"Retrying connection in {self.reconnect_delay} seconds...")
+                logger.debug(
+                    f"Retrying connection in {self.reconnect_delay} seconds..."
+                )
                 time.sleep(self.reconnect_delay)
-        
+
         logger.error("Failed to establish WebSocket connection after all attempts")
         return False
-    
+
     def _run_with_ping(self):
         """Run WebSocket with automatic ping mechanism."""
         try:
@@ -97,7 +103,7 @@ class WebSocketConnectionManager:
         except Exception as e:
             logger.error(f"WebSocket run_forever failed: {e}")
             self.ws_error = e
-    
+
     def _send_ping(self):
         """Send ping message to keep connection alive."""
         if self.ws and not self.connection_lost:
@@ -109,23 +115,25 @@ class WebSocketConnectionManager:
             except Exception as e:
                 logger.warning(f"Failed to send ping: {e}")
                 self.connection_lost = True
-    
+
     def _check_connection_health(self):
         """Check if connection is healthy based on ping/pong timing."""
         current_time = time.time()
-        
+
         # Send ping if interval has passed
         if current_time - self.last_ping_time > self.ping_interval:
             self._send_ping()
-        
+
         # Check if we haven't received pong in time
-        if (self.last_ping_time > 0 and 
-            self.last_pong_time < self.last_ping_time and 
-            current_time - self.last_ping_time > self.ping_timeout):
+        if (
+            self.last_ping_time > 0
+            and self.last_pong_time < self.last_ping_time
+            and current_time - self.last_ping_time > self.ping_timeout
+        ):
             logger.warning("Ping timeout - connection may be lost")
             with self._lock:
                 self.connection_lost = True
-    
+
     def _on_open(self, ws):
         """Handle WebSocket connection open."""
         with self._lock:
@@ -133,12 +141,14 @@ class WebSocketConnectionManager:
             self.last_ping_time = time.time()
             self.last_pong_time = time.time()
         logger.debug("WebSocket connection established")
-    
+
     def _on_message(self, ws, message):
         """Handle incoming WebSocket messages."""
         try:
             data = json.loads(message)
-            logger.debug(f"Received WebSocket message: {json.dumps(data, indent=2)[:200]}...")
+            logger.debug(
+                f"Received WebSocket message: {json.dumps(data, indent=2)[:200]}..."
+            )
 
             if data.get("type") == "pong":
                 with self._lock:
@@ -158,7 +168,9 @@ class WebSocketConnectionManager:
                 if self.accumulate_messages_window <= 0 and self.final_response is None:
                     self.final_response = extracted_text
 
-            logger.debug(f"Received preview broadcast message: {extracted_text[:100]}...")
+            logger.debug(
+                f"Received preview broadcast message: {extracted_text[:100]}..."
+            )
 
         except json.JSONDecodeError:
             logger.warning(f"Failed to decode WebSocket message: {message[:100]}...")
@@ -199,30 +211,30 @@ class WebSocketConnectionManager:
                 return "\n".join(text_parts)
 
         return None
-    
+
     def _on_error(self, ws, error):
         """Handle WebSocket errors."""
         with self._lock:
             self.ws_error = error
             self.connection_lost = True
         logger.error(f"WebSocket error: {error}")
-    
+
     def _on_close(self, ws, close_status_code, close_msg):
         """Handle WebSocket closure."""
         with self._lock:
             self.connection_lost = True
         logger.debug(f"WebSocket closed with code {close_status_code}: {close_msg}")
-    
+
     def _on_ping(self, ws, message):
         """Handle WebSocket ping from server."""
         logger.debug("Received WebSocket ping from server")
-    
+
     def _on_pong(self, ws, message):
         """Handle WebSocket pong from server."""
         with self._lock:
             self.last_pong_time = time.time()
         logger.debug("Received WebSocket pong from server")
-    
+
     def wait_for_response(self) -> Optional[str]:
         """Wait for response with connection health monitoring and reconnection."""
         start_time = time.time()
@@ -230,7 +242,11 @@ class WebSocketConnectionManager:
         while (time.time() - start_time) < self.timeout:
             self._check_connection_health()
 
-            if self.connection_lost and self.final_response is None and not self._has_received_messages():
+            if (
+                self.connection_lost
+                and self.final_response is None
+                and not self._has_received_messages()
+            ):
                 logger.warning("Connection lost, attempting to reconnect...")
                 self.close()
 
@@ -281,15 +297,15 @@ class WebSocketConnectionManager:
                 self.final_response = "\n".join(self._received_messages)
                 return True
             return False
-    
+
     def close(self):
         """Close WebSocket connection and cleanup."""
         try:
             if self.ws:
                 self.ws.close()
-        except:
+        except Exception:
             pass
-        
+
         # Only join thread if we're not calling from within the WebSocket thread itself
         if self.ws_thread and self.ws_thread.is_alive():
             current_thread = threading.current_thread()
@@ -311,7 +327,7 @@ class WeniTarget(BaseTarget):
         timeout: int = 480,
         connect_ws_first: bool = False,
         accumulate_messages_window: float = 0.0,
-        **kwargs
+        **kwargs,
     ):
         """Initialize the target.
 
@@ -333,22 +349,22 @@ class WeniTarget(BaseTarget):
                 behavior of returning the first broadcast message.
         """
         super().__init__()
-        
+
         # Try multiple sources for project_uuid and bearer_token:
         # 1. Direct parameter
         # 2. Environment variable
         # 3. Weni CLI cache (fallback)
         store = Store()
-        
+
         self.project_uuid = (
-            weni_project_uuid or 
-            os.environ.get("WENI_PROJECT_UUID") or 
-            store.get_project_uuid()
+            weni_project_uuid
+            or os.environ.get("WENI_PROJECT_UUID")
+            or store.get_project_uuid()
         )
         self.bearer_token = (
-            weni_bearer_token or 
-            os.environ.get("WENI_BEARER_TOKEN") or 
-            store.get_token()
+            weni_bearer_token
+            or os.environ.get("WENI_BEARER_TOKEN")
+            or store.get_token()
         )
         self.language = language
         self.timeout = timeout
@@ -371,11 +387,11 @@ class WeniTarget(BaseTarget):
                 "2. Or set WENI_BEARER_TOKEN environment variable\n"
                 "3. Or provide 'weni_bearer_token' in your test configuration"
             )
-        
+
         # Generate unique contact URN for this test session
         # This ensures each test case has its own conversation history
         self.contact_urn = f"ext:{uuid.uuid4().hex}"
-        
+
         # API endpoints
         self.api_base_url = "https://nexus.weni.ai"
         self.api_endpoint = f"{self.api_base_url}/api/{self.project_uuid}/preview/"
@@ -383,7 +399,7 @@ class WeniTarget(BaseTarget):
             f"wss://nexus.weni.ai/ws/preview/{self.project_uuid}/"
             f"?Token={self.bearer_token}"
         )
-        
+
         logger.debug(f"Initialized WeniTarget with project UUID: {self.project_uuid}")
         logger.debug(f"Using contact URN: {self.contact_urn}")
 
@@ -410,8 +426,8 @@ class WeniTarget(BaseTarget):
                 data={
                     "contact_urn": self.contact_urn,
                     "language": self.language,
-                    "session_id": self.contact_urn
-                }
+                    "session_id": self.contact_urn,
+                },
             )
 
         except Exception as e:
@@ -428,8 +444,8 @@ class WeniTarget(BaseTarget):
                     "contact_urn": self.contact_urn,
                     "language": self.language,
                     "session_id": self.contact_urn,
-                    "error": True
-                }
+                    "error": True,
+                },
             )
 
     def _invoke_with_ws_first(self, prompt: str) -> str:
@@ -486,101 +502,102 @@ class WeniTarget(BaseTarget):
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/139.0.0.0 Safari/537.36"
-            )
+            ),
         }
-        
+
         data = {
             "text": prompt,
             "attachments": [],
             "contact_urn": self.contact_urn,
-            "language": self.language
+            "language": self.language,
         }
-        
+
         logger.debug(f"Sending POST request to {self.api_endpoint}")
-        
+
         response = requests.post(
-            self.api_endpoint,
-            headers=headers,
-            json=data,
-            timeout=10
+            self.api_endpoint, headers=headers, json=data, timeout=10
         )
-        
+
         try:
             response.raise_for_status()
-            logger.debug(f"Successfully sent prompt to Weni API. Status: {response.status_code}")
+            logger.debug(
+                f"Successfully sent prompt to Weni API. Status: {response.status_code}"
+            )
         except requests.exceptions.HTTPError as e:
             self._handle_http_error(response, e)
 
-    def _handle_http_error(self, response: requests.Response, error: requests.exceptions.HTTPError) -> None:
+    def _handle_http_error(
+        self, response: requests.Response, error: requests.exceptions.HTTPError
+    ) -> None:
         """Handle HTTP errors with helpful error messages.
-        
+
         Args:
             response: The HTTP response object
             error: The original HTTPError
-            
+
         Raises:
             ValueError: With a helpful error message based on the status code
         """
         status_code = response.status_code
-        
+
         if status_code == 401:
             # Unauthorized - likely invalid token
             error_msg = (
-                f"Authentication failed (401 Unauthorized). "
-                f"The bearer token is invalid or expired.\n\n"
-                f"To fix this issue:\n"
-                f"1. Install and use Weni CLI (recommended): 'pip install weni-cli && weni login'\n"
-                f"   Get Weni CLI at: https://github.com/weni-ai/weni-cli\n"
-                f"2. Or set a valid token in environment variable: WENI_BEARER_TOKEN=your_token\n"
-                f"3. Or provide 'weni_bearer_token' in your test configuration\n\n"
-                f"Get your token manually from: https://intelligence.weni.ai (User menu > API Token)"
+                "Authentication failed (401 Unauthorized). "
+                "The bearer token is invalid or expired.\n\n"
+                "To fix this issue:\n"
+                "1. Install and use Weni CLI (recommended): 'pip install weni-cli && weni login'\n"
+                "   Get Weni CLI at: https://github.com/weni-ai/weni-cli\n"
+                "2. Or set a valid token in environment variable: WENI_BEARER_TOKEN=your_token\n"
+                "3. Or provide 'weni_bearer_token' in your test configuration\n\n"
+                "Get your token manually from: https://intelligence.weni.ai (User menu > API Token)"
             )
             raise ValueError(error_msg) from error
-            
+
         elif status_code == 403:
             # Forbidden - likely no access to project
             error_msg = (
-                f"Access forbidden (403 Forbidden). "
-                f"You don't have permission to access this project.\n\n"
-                f"To fix this issue:\n"
+                "Access forbidden (403 Forbidden). "
+                "You don't have permission to access this project.\n\n"
+                "To fix this issue:\n"
                 f"1. Verify the project UUID is correct: {self.project_uuid}\n"
-                f"2. Ensure you have access to this project in Weni\n"
-                f"3. Contact your project administrator if needed"
+                "2. Ensure you have access to this project in Weni\n"
+                "3. Contact your project administrator if needed"
             )
             raise ValueError(error_msg) from error
-            
+
         elif status_code == 404:
             # Not found - likely invalid project UUID
             error_msg = (
-                f"Project not found (404 Not Found). "
+                "Project not found (404 Not Found). "
                 f"The project UUID '{self.project_uuid}' does not exist or is invalid.\n\n"
-                f"To fix this issue:\n"
-                f"1. Use Weni CLI to select the correct project (recommended): 'weni project use [project-uuid]'\n"
-                f"   Get Weni CLI at: https://github.com/weni-ai/weni-cli\n"
-                f"2. Or set the correct UUID in environment variable: WENI_PROJECT_UUID=your_uuid\n"
-                f"3. Or provide 'weni_project_uuid' in your test configuration\n\n"
-                f"Find your project UUID manually at: https://intelligence.weni.ai (Project Settings > General)"
+                "To fix this issue:\n"
+                "1. Use Weni CLI to select the correct project (recommended): 'weni project use [project-uuid]'\n"
+                "   Get Weni CLI at: https://github.com/weni-ai/weni-cli\n"
+                "2. Or set the correct UUID in environment variable: WENI_PROJECT_UUID=your_uuid\n"
+                "3. Or provide 'weni_project_uuid' in your test configuration\n\n"
+                "Find your project UUID manually at: https://intelligence.weni.ai (Project Settings > General)"
             )
             raise ValueError(error_msg) from error
-            
+
         elif status_code >= 500:
             # Server error
             error_msg = (
                 f"Weni server error ({status_code}). "
-                f"The Weni API is experiencing issues.\n\n"
-                f"To fix this issue:\n"
-                f"1. Wait a few minutes and try again\n"
-                f"2. Check Weni status page for known issues\n"
-                f"3. Contact Weni support if the problem persists"
+                "The Weni API is experiencing issues.\n\n"
+                "To fix this issue:\n"
+                "1. Wait a few minutes and try again\n"
+                "2. Check Weni status page for known issues\n"
+                "3. Contact Weni support if the problem persists"
             )
             raise ValueError(error_msg) from error
-            
+
         else:
             # Other HTTP errors
             error_msg = (
                 f"HTTP error {status_code}: {response.reason}\n"
                 f"URL: {response.url}\n\n"
-                f"Please check your configuration and try again."
+                "Please check your configuration and try again."
             )
             raise ValueError(error_msg) from error
 
@@ -619,7 +636,7 @@ class WeniTarget(BaseTarget):
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
                 "AppleWebKit/537.36 (KHTML, like Gecko) "
                 "Chrome/139.0.0.0 Safari/537.36"
-            )
+            ),
         }
 
         logger.debug(f"Connecting to WebSocket: {self.ws_endpoint[:50]}...")

--- a/src/agenteval/targets/weni/target.py
+++ b/src/agenteval/targets/weni/target.py
@@ -20,11 +20,21 @@ logger = logging.getLogger(__name__)
 
 class WebSocketConnectionManager:
     """Manages WebSocket connections with ping/pong and reconnection logic."""
-    
-    def __init__(self, endpoint: str, headers: dict, timeout: int):
+
+    def __init__(
+        self,
+        endpoint: str,
+        headers: dict,
+        timeout: int,
+        accumulate_messages_window: float = 0.0,
+    ):
         self.endpoint = endpoint
         self.headers = headers
         self.timeout = timeout
+        # When > 0, the manager waits this many seconds without a new broadcast message
+        # before considering the agent response complete. When 0 (default), the first
+        # broadcast message ends the wait, preserving the legacy single-message behavior.
+        self.accumulate_messages_window = accumulate_messages_window
         self.ws = None
         self.ws_thread = None
         self.final_response = None
@@ -37,6 +47,8 @@ class WebSocketConnectionManager:
         self.reconnect_delay = 2  # seconds
         self.ping_timeout = 10  # seconds to wait for pong response
         self._lock = threading.Lock()
+        self._received_messages: list[str] = []
+        self._last_message_time: float = 0.0
         
     def connect(self) -> bool:
         """Establish WebSocket connection with retry logic."""
@@ -127,45 +139,66 @@ class WebSocketConnectionManager:
         try:
             data = json.loads(message)
             logger.debug(f"Received WebSocket message: {json.dumps(data, indent=2)[:200]}...")
-            
-            # Handle pong messages
+
             if data.get("type") == "pong":
                 with self._lock:
                     self.last_pong_time = time.time()
                 logger.debug("Received pong response")
                 return
-            
-            # Check for preview message format
-            if data.get("type") == "preview":
-                message_data = data.get("message", {})
-                if message_data.get("type") == "preview":
-                    content = message_data.get("content", {})
-                    if content.get("type") == "broadcast" and "message" in content:
-                        message_content = content["message"]
 
-                        # Handle both string and array formats
-                        if isinstance(message_content, str):
-                            # Simple string format
-                            self.final_response = message_content
-                        elif isinstance(message_content, list) and len(message_content) > 0:
-                            # Array format - concatenate all text messages
-                            text_parts = []
-                            for msg in message_content:
-                                if isinstance(msg, dict) and "msg" in msg:
-                                    msg_obj = msg["msg"]
-                                    if isinstance(msg_obj, dict) and "text" in msg_obj:
-                                        text_parts.append(msg_obj["text"])
+            extracted_text = self._extract_broadcast_text(data)
+            if not extracted_text:
+                return
 
-                            if text_parts:
-                                self.final_response = "\n".join(text_parts)
-                        
-                        if self.final_response:
-                            logger.debug(f"Received preview broadcast message: {self.final_response[:100]}...")
+            with self._lock:
+                self._received_messages.append(extracted_text)
+                self._last_message_time = time.time()
+                # Legacy mode (window == 0): first broadcast wins and ends the wait.
+                # Accumulating mode (window > 0): final_response is set later by wait_for_response.
+                if self.accumulate_messages_window <= 0 and self.final_response is None:
+                    self.final_response = extracted_text
+
+            logger.debug(f"Received preview broadcast message: {extracted_text[:100]}...")
 
         except json.JSONDecodeError:
             logger.warning(f"Failed to decode WebSocket message: {message[:100]}...")
         except Exception as e:
             logger.error(f"Error processing WebSocket message: {str(e)}")
+
+    @staticmethod
+    def _extract_broadcast_text(data: dict) -> Optional[str]:
+        """Extract text content from a preview broadcast message payload.
+
+        Returns:
+            The extracted text, or None if the payload is not a recognized broadcast.
+        """
+        if data.get("type") != "preview":
+            return None
+
+        message_data = data.get("message", {})
+        if message_data.get("type") != "preview":
+            return None
+
+        content = message_data.get("content", {})
+        if content.get("type") != "broadcast" or "message" not in content:
+            return None
+
+        message_content = content["message"]
+
+        if isinstance(message_content, str):
+            return message_content
+
+        if isinstance(message_content, list) and len(message_content) > 0:
+            text_parts = []
+            for msg in message_content:
+                if isinstance(msg, dict) and "msg" in msg:
+                    msg_obj = msg["msg"]
+                    if isinstance(msg_obj, dict) and "text" in msg_obj:
+                        text_parts.append(msg_obj["text"])
+            if text_parts:
+                return "\n".join(text_parts)
+
+        return None
     
     def _on_error(self, ws, error):
         """Handle WebSocket errors."""
@@ -193,32 +226,61 @@ class WebSocketConnectionManager:
     def wait_for_response(self) -> Optional[str]:
         """Wait for response with connection health monitoring and reconnection."""
         start_time = time.time()
-        
-        while self.final_response is None and (time.time() - start_time) < self.timeout:
-            # Check connection health and send pings
+
+        while (time.time() - start_time) < self.timeout:
             self._check_connection_health()
-            
-            # Handle connection loss with reconnection
-            if self.connection_lost and self.final_response is None:
+
+            if self.connection_lost and self.final_response is None and not self._has_received_messages():
                 logger.warning("Connection lost, attempting to reconnect...")
                 self.close()
-                
+
                 if not self.connect():
                     break
-            
-            # Check for WebSocket errors
+
             if self.ws_error:
                 logger.error(f"WebSocket error occurred: {self.ws_error}")
-                return None  # Let the timeout handling deal with this
-            
+                return None
+
+            if self._is_response_complete():
+                break
+
             time.sleep(0.1)
-        
-        # Close connection when we have a response or timeout
+
+        # Finalize accumulated response if in accumulating mode and timeout was not hit.
+        if self.accumulate_messages_window > 0 and self.final_response is None:
+            with self._lock:
+                if self._received_messages:
+                    self.final_response = "\n".join(self._received_messages)
+
         if self.final_response is not None:
             logger.debug("Response received, closing WebSocket connection")
             self.close()
-        
+
         return self.final_response
+
+    def _has_received_messages(self) -> bool:
+        with self._lock:
+            return len(self._received_messages) > 0
+
+    def _is_response_complete(self) -> bool:
+        """Check whether the manager has enough to consider the response complete.
+
+        - Legacy mode (window == 0): completion is signaled by `final_response` being set
+          on the first broadcast received.
+        - Accumulating mode (window > 0): completion is reached when at least one broadcast
+          arrived and no new broadcast was received within the configured quiet window.
+        """
+        if self.accumulate_messages_window <= 0:
+            return self.final_response is not None
+
+        with self._lock:
+            if not self._received_messages:
+                return False
+            quiet_elapsed = time.time() - self._last_message_time
+            if quiet_elapsed >= self.accumulate_messages_window:
+                self.final_response = "\n".join(self._received_messages)
+                return True
+            return False
     
     def close(self):
         """Close WebSocket connection and cleanup."""
@@ -247,17 +309,28 @@ class WeniTarget(BaseTarget):
         weni_bearer_token: Optional[str] = None,
         language: str = "en-US",
         timeout: int = 480,
+        connect_ws_first: bool = False,
+        accumulate_messages_window: float = 0.0,
         **kwargs
     ):
         """Initialize the target.
 
         Args:
-            weni_project_uuid (Optional[str]): The Weni project UUID. 
+            weni_project_uuid (Optional[str]): The Weni project UUID.
                 If not provided, will be read from WENI_PROJECT_UUID env var or weni-cli cache.
-            weni_bearer_token (Optional[str]): The Weni bearer token. 
+            weni_bearer_token (Optional[str]): The Weni bearer token.
                 If not provided, will be read from WENI_BEARER_TOKEN env var or weni-cli cache.
             language (str): The language for the conversation. Defaults to "pt-BR".
-            timeout (int): Maximum time to wait for agent response in seconds. Defaults to 30.
+            timeout (int): Maximum time to wait for agent response in seconds. Defaults to 480.
+            connect_ws_first (bool): When True, establish the WebSocket connection before
+                sending the POST request. Closes the race window where the agent broadcasts
+                a response before the listener is ready. Defaults to False to preserve the
+                legacy behavior.
+            accumulate_messages_window (float): When > 0, collect every broadcast message
+                received and wait this many seconds without a new message before returning
+                the concatenated response. Useful for agents that emit multiple messages
+                per turn (e.g. text + catalog). Defaults to 0, which preserves the legacy
+                behavior of returning the first broadcast message.
         """
         super().__init__()
         
@@ -279,7 +352,9 @@ class WeniTarget(BaseTarget):
         )
         self.language = language
         self.timeout = timeout
-        
+        self.connect_ws_first = connect_ws_first
+        self.accumulate_messages_window = accumulate_messages_window
+
         if not self.project_uuid:
             raise ValueError(
                 "weni_project_uuid is required. Please:\n"
@@ -323,13 +398,13 @@ class WeniTarget(BaseTarget):
         """
         try:
             logger.debug(f"Invoking Weni agent with prompt: {prompt}")
-            
-            # Send the prompt via POST request
-            self._send_prompt(prompt)
-            
-            # Connect to WebSocket and wait for response
-            response_text = self._wait_for_response()
-            
+
+            if self.connect_ws_first:
+                response_text = self._invoke_with_ws_first(prompt)
+            else:
+                self._send_prompt(prompt)
+                response_text = self._wait_for_response()
+
             return TargetResponse(
                 response=response_text,
                 data={
@@ -338,9 +413,8 @@ class WeniTarget(BaseTarget):
                     "session_id": self.contact_urn
                 }
             )
-            
+
         except Exception as e:
-            # Handle any unexpected errors gracefully
             error_message = (
                 f"UNEXPECTED ERROR: {str(e)} - "
                 f"An unexpected error occurred while invoking the Weni agent. "
@@ -348,7 +422,6 @@ class WeniTarget(BaseTarget):
             )
             logger.error(f"Error invoking Weni agent: {error_message}")
 
-            # Return error response instead of raising exception
             return TargetResponse(
                 response=error_message,
                 data={
@@ -358,6 +431,33 @@ class WeniTarget(BaseTarget):
                     "error": True
                 }
             )
+
+    def _invoke_with_ws_first(self, prompt: str) -> str:
+        """Open the WebSocket before sending the prompt to avoid losing early broadcasts.
+
+        Args:
+            prompt (str): The prompt to send to the agent.
+
+        Returns:
+            str: The agent's final response text (or an error message if the WS connection
+                or wait fails).
+        """
+        connection_manager = self._build_connection_manager()
+
+        if not connection_manager.connect():
+            error_message = (
+                "CONNECTION ERROR: Failed to establish WebSocket connection after multiple attempts. "
+                "This could indicate network connectivity issues, invalid credentials, or server problems. "
+                "Test case marked as failed."
+            )
+            logger.error(error_message)
+            return error_message
+
+        try:
+            self._send_prompt(prompt)
+            return self._collect_response(connection_manager)
+        finally:
+            connection_manager.close()
 
     def _send_prompt(self, prompt: str) -> None:
         """Send a prompt to the Weni API.
@@ -487,13 +587,31 @@ class WeniTarget(BaseTarget):
     def _wait_for_response(self) -> str:
         """Connect to WebSocket and wait for the agent's final response.
 
-        Returns:
-            str: The agent's final response text.
+        Used when ``connect_ws_first`` is False: the WS is established after the POST
+        has already been sent (legacy ordering).
 
-        Raises:
-            TimeoutError: If no response is received within the timeout period.
+        Returns:
+            str: The agent's final response text, or an error message if the connection
+                fails or the wait times out.
         """
-        # Configure WebSocket headers
+        connection_manager = self._build_connection_manager()
+
+        if not connection_manager.connect():
+            error_message = (
+                "CONNECTION ERROR: Failed to establish WebSocket connection after multiple attempts. "
+                "This could indicate network connectivity issues, invalid credentials, or server problems. "
+                "Test case marked as failed."
+            )
+            logger.error(error_message)
+            return error_message
+
+        try:
+            return self._collect_response(connection_manager)
+        finally:
+            connection_manager.close()
+
+    def _build_connection_manager(self) -> WebSocketConnectionManager:
+        """Build a `WebSocketConnectionManager` configured for this target."""
         headers = {
             "Origin": "https://intelligence-next.weni.ai",
             "Accept-Language": "en-US,en;q=0.9,pt-BR;q=0.8,pt;q=0.7,es;q=0.6,nl;q=0.5,fr;q=0.4",
@@ -503,43 +621,27 @@ class WeniTarget(BaseTarget):
                 "Chrome/139.0.0.0 Safari/537.36"
             )
         }
-        
+
         logger.debug(f"Connecting to WebSocket: {self.ws_endpoint[:50]}...")
-        
-        # Create connection manager with ping/pong and reconnection support
-        connection_manager = WebSocketConnectionManager(
+
+        return WebSocketConnectionManager(
             endpoint=self.ws_endpoint,
             headers=headers,
-            timeout=self.timeout
+            timeout=self.timeout,
+            accumulate_messages_window=self.accumulate_messages_window,
         )
-        
-        # Establish initial connection
-        if not connection_manager.connect():
+
+    def _collect_response(self, connection_manager: WebSocketConnectionManager) -> str:
+        """Wait for the agent's response on an already-connected manager."""
+        final_response = connection_manager.wait_for_response()
+
+        if final_response is None:
             error_message = (
-                f"CONNECTION ERROR: Failed to establish WebSocket connection after multiple attempts. "
-                f"This could indicate network connectivity issues, invalid credentials, or server problems. "
+                f"TIMEOUT ERROR: No response received from Weni agent within {self.timeout} seconds. "
+                f"This could indicate network issues, agent processing delays, or WebSocket connection problems. "
                 f"Test case marked as failed."
             )
             logger.error(error_message)
             return error_message
-        
-        try:
-            # Wait for response with automatic reconnection and ping/pong
-            final_response = connection_manager.wait_for_response()
-            
-            if final_response is None:
-                # Instead of raising an exception, return an error response
-                # This allows the test to continue with other test cases
-                error_message = (
-                    f"TIMEOUT ERROR: No response received from Weni agent within {self.timeout} seconds. "
-                    f"This could indicate network issues, agent processing delays, or WebSocket connection problems. "
-                    f"Test case marked as failed."
-                )
-                logger.error(error_message)
-                return error_message
-            
-            return final_response
-            
-        finally:
-            # Ensure WebSocket is properly closed
-            connection_manager.close()
+
+        return final_response

--- a/src/agenteval/utils/store.py
+++ b/src/agenteval/utils/store.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-STORE_TOKEN_KEY = "token"
+STORE_TOKEN_KEY = "token"  # nosec B105 - name of the JSON key in the local cache file, not a credential
 STORE_PROJECT_UUID_KEY = "project_uuid"
 STORE_WENI_BASE_URL = "weni_base_url"
 STORE_NEXUS_BASE_URL = "nexus_base_url"

--- a/src/agenteval/utils/store.py
+++ b/src/agenteval/utils/store.py
@@ -1,9 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -22,11 +22,11 @@ STORE_CLI_BASE_URL = "cli_base_url"
 class Store:
     """
     A utility class to interact with the Weni CLI cache file.
-    
+
     This class provides methods to read configuration values (like tokens and project UUIDs)
     from the Weni CLI cache file, which is typically stored at ~/.weni_cli
     """
-    
+
     def __init__(self):
         self.file_path = f"{Path.home()}{os.sep}.weni_cli"
         logger.debug(f"Store initialized with file path: {self.file_path}")
@@ -34,11 +34,11 @@ class Store:
     def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
         """
         Get a value from the store by key.
-        
+
         Args:
             key (str): The key to look up
             default (Optional[str]): Default value if key is not found
-            
+
         Returns:
             Optional[str]: The value associated with the key, or default if not found
         """
@@ -46,18 +46,20 @@ class Store:
             if not os.path.exists(self.file_path):
                 logger.debug(f"Store file does not exist at {self.file_path}")
                 return default
-                
+
             with open(self.file_path, "r") as file:
                 content = file.read().strip()
                 if not content:
                     logger.debug("Store file is empty")
                     return default
-                    
+
                 data = json.loads(content)
                 value = data.get(key, default)
-                logger.debug(f"Retrieved value for key '{key}': {'***' if 'token' in key.lower() else value}")
+                logger.debug(
+                    f"Retrieved value for key '{key}': {'***' if 'token' in key.lower() else value}"
+                )
                 return value
-                
+
         except (json.JSONDecodeError, IOError) as e:
             logger.warning(f"Error reading from store file: {e}")
             return default
@@ -65,7 +67,7 @@ class Store:
     def get_token(self) -> Optional[str]:
         """
         Get the Weni authentication token from the store.
-        
+
         Returns:
             Optional[str]: The authentication token, or None if not found
         """
@@ -74,7 +76,7 @@ class Store:
     def get_project_uuid(self) -> Optional[str]:
         """
         Get the Weni project UUID from the store.
-        
+
         Returns:
             Optional[str]: The project UUID, or None if not found
         """

--- a/tests/src/agenteval/plan/test_plan.py
+++ b/tests/src/agenteval/plan/test_plan.py
@@ -73,8 +73,8 @@ class TestPlan:
             ),
         ],
     )
-    def test_resolve_num_threads(self, num_tests, num_threads, expected):
-        threads = plan.Plan._resolve_num_threads(
+    def test_resolve_num_threads(self, plan_fixture, num_tests, num_threads, expected):
+        threads = plan_fixture._resolve_num_threads(
             num_tests=num_tests, num_threads=num_threads
         )
         assert threads == expected
@@ -96,7 +96,7 @@ class TestPlan:
 
         plan_fixture.run(False, None, None, None)
 
-        spy_setup_run.assert_called_once_with(None, None, None)
+        spy_setup_run.assert_called_once_with(None, None, None, False)
         mock_log_run_start.assert_called_once()
         mock_run_concurrent.assert_called_once()
         mock_log_run_end.assert_called_once()

--- a/tests/src/agenteval/targets/weni/test_target.py
+++ b/tests/src/agenteval/targets/weni/test_target.py
@@ -162,44 +162,36 @@ class TestWeniTarget:
     @patch('src.agenteval.targets.weni.target.requests.post')
     @patch('src.agenteval.targets.weni.target.websocket.WebSocketApp')
     def test_timeout_handling(self, mock_websocket, mock_post, weni_target_with_params):
-        """Test timeout handling when no response is received."""
-        # Mock POST request
+        """When no response arrives within the timeout, invoke returns a TIMEOUT ERROR response."""
         mock_post.return_value = MagicMock(status_code=200)
-        
-        # Mock WebSocket without sending any finalResponse
+
         mock_ws_instance = MagicMock()
         mock_websocket.return_value = mock_ws_instance
-        
-        # Set a very short timeout for testing
+
         weni_target_with_params.timeout = 0.1
-        
-        # Invoke should raise TimeoutError
-        with pytest.raises(TimeoutError, match="No response received"):
-            weni_target_with_params.invoke("Test prompt")
-    
+
+        response = weni_target_with_params.invoke("Test prompt")
+
+        assert response.response.startswith("TIMEOUT ERROR: No response received from Weni agent")
+
     @patch('src.agenteval.targets.weni.target.requests.post')
     @patch('src.agenteval.targets.weni.target.websocket.WebSocketApp')
     def test_websocket_error_handling(self, mock_websocket, mock_post, weni_target_fixture):
-        """Test WebSocket error handling."""
-        # Mock POST request
+        """When the WebSocket fails to connect, invoke returns a CONNECTION ERROR response."""
         mock_post.return_value = MagicMock(status_code=200)
-        
-        # Mock WebSocket to simulate an error
+
         mock_ws_instance = MagicMock()
         mock_websocket.return_value = mock_ws_instance
-        
+
         def simulate_ws_error():
-            # Get the on_error callback
             on_error = mock_websocket.call_args[1]['on_error']
-            
-            # Simulate a WebSocket error
             on_error(mock_ws_instance, "Connection failed")
-        
+
         mock_ws_instance.run_forever.side_effect = simulate_ws_error
-        
-        # Invoke should raise RuntimeError
-        with pytest.raises(RuntimeError, match="WebSocket error occurred"):
-            weni_target_fixture.invoke("Test prompt")
+
+        response = weni_target_fixture.invoke("Test prompt")
+
+        assert response.response.startswith("CONNECTION ERROR: Failed to establish WebSocket connection")
     
     @patch('src.agenteval.targets.weni.target.Store')
     def test_initialization_with_store_fallback(self, mock_store_class, monkeypatch):

--- a/tests/src/agenteval/targets/weni/test_target.py
+++ b/tests/src/agenteval/targets/weni/test_target.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import time
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -419,3 +420,100 @@ class TestWeniTarget:
             assert "weni_project_uuid" in error_message
         else:
             pytest.fail("Expected ValueError to be raised")
+
+    def test_default_new_params(self, weni_target_fixture):
+        """The new opt-in params must default to disabled (legacy behavior)."""
+        assert weni_target_fixture.connect_ws_first is False
+        assert weni_target_fixture.accumulate_messages_window == 0.0
+
+    def test_initialization_with_new_params(self):
+        """Both new params are stored on the target."""
+        weni_target = target.WeniTarget(
+            weni_project_uuid="test-project-uuid",
+            weni_bearer_token="test-bearer-token",
+            connect_ws_first=True,
+            accumulate_messages_window=1.5,
+        )
+        assert weni_target.connect_ws_first is True
+        assert weni_target.accumulate_messages_window == 1.5
+
+    @patch("src.agenteval.targets.weni.target.requests.post")
+    @patch("src.agenteval.targets.weni.target.websocket.WebSocketApp")
+    def test_invoke_with_connect_ws_first_opens_ws_before_post(self, mock_websocket, mock_post):
+        """When connect_ws_first=True the WebSocket must be created before the POST is sent."""
+        call_order: list[str] = []
+
+        mock_ws_instance = MagicMock()
+
+        def record_ws_create(*args, **kwargs):
+            call_order.append("ws_create")
+            # Trigger the broadcast message during run_forever so wait_for_response returns.
+            on_message = kwargs["on_message"]
+
+            def fake_run_forever():
+                test_message = {
+                    "type": "preview",
+                    "message": {
+                        "type": "preview",
+                        "content": {"type": "broadcast", "message": "Response after WS"},
+                    },
+                }
+                on_message(mock_ws_instance, json.dumps(test_message))
+
+            mock_ws_instance.run_forever.side_effect = fake_run_forever
+            return mock_ws_instance
+
+        mock_websocket.side_effect = record_ws_create
+
+        def record_post(*args, **kwargs):
+            call_order.append("post")
+            return MagicMock(status_code=200)
+
+        mock_post.side_effect = record_post
+
+        weni_target = target.WeniTarget(
+            weni_project_uuid="test-project-uuid",
+            weni_bearer_token="test-bearer-token",
+            timeout=5,
+            connect_ws_first=True,
+        )
+
+        response = weni_target.invoke("Test prompt")
+
+        assert response.response == "Response after WS"
+        assert call_order == ["ws_create", "post"]
+
+    @patch("src.agenteval.targets.weni.target.requests.post")
+    @patch("src.agenteval.targets.weni.target.websocket.WebSocketApp")
+    def test_invoke_accumulates_multiple_messages(self, mock_websocket, mock_post):
+        """When accumulate_messages_window > 0, multiple broadcasts are joined."""
+        mock_post.return_value = MagicMock(status_code=200)
+
+        mock_ws_instance = MagicMock()
+        mock_websocket.return_value = mock_ws_instance
+
+        def simulate_ws_run():
+            on_message = mock_websocket.call_args[1]["on_message"]
+            for body in ("First message", "Second message", "Third message"):
+                test_message = {
+                    "type": "preview",
+                    "message": {
+                        "type": "preview",
+                        "content": {"type": "broadcast", "message": body},
+                    },
+                }
+                on_message(mock_ws_instance, json.dumps(test_message))
+                time.sleep(0.05)
+
+        mock_ws_instance.run_forever.side_effect = simulate_ws_run
+
+        weni_target = target.WeniTarget(
+            weni_project_uuid="test-project-uuid",
+            weni_bearer_token="test-bearer-token",
+            timeout=5,
+            accumulate_messages_window=0.3,
+        )
+
+        response = weni_target.invoke("Test prompt")
+
+        assert response.response == "First message\nSecond message\nThird message"

--- a/tests/src/agenteval/test_cli.py
+++ b/tests/src/agenteval/test_cli.py
@@ -30,7 +30,7 @@ def test_run(mocker):
     result = runner.invoke(cli.cli, ["run"])
 
     mock_run.assert_called_once_with(
-        verbose=False, num_threads=None, work_dir=None, filter=None
+        verbose=False, num_threads=None, work_dir=None, filter=None, watch=False
     )
     assert result.exit_code == 0
 


### PR DESCRIPTION
## Contexto
Um cliente reportou que o `weni eval` travava ao executar testes com 3 ou mais
steps em fluxos que disparam catálogo (ex.: "Olá" → "Quero comprar X" → "Meu CEP é Y").
A investigação descartou hipóteses iniciais (limite de `max_turns` e timeout do target)
e identificou dois bugs no `WeniTarget` que se compõem para causar o sintoma:
1. **Race condition entre POST e WebSocket**: o `WeniTarget` envia o POST ao agente
   *antes* de estabelecer a conexão WebSocket. Em fluxos onde o agente responde
   rapidamente, broadcasts iniciais chegam antes do listener estar pronto e são
   perdidas, deixando o turno aguardar o timeout completo (480s).
2. **Captura parcial de mensagens**: o handler `_on_message` finaliza o turno na
   primeira broadcast recebida. Em respostas multi-mensagem (texto + catálogo +
   follow-up), apenas a primeira é capturada e o resto é descartado, levando o
   avaliador a reprovar testes corretos.
Reprodução: o cliente conseguiu fazer o teste "passar" abrindo o painel da Weni
em paralelo (mantendo um WS quente), mas o `WeniTarget` capturou apenas o texto
intermediário "me informa o CEP" e ignorou o catálogo enviado depois — o teste
foi reprovado por captura errada, não por falha do agente.
## Solução
Adiciona dois parâmetros **opt-in** ao `WeniTarget`:
- `connect_ws_first: bool = False` — quando `True`, estabelece o WebSocket
  antes de enviar o POST, fechando a janela de race.
- `accumulate_messages_window: float = 0.0` — quando `> 0`, coleta todas as
  broadcasts recebidas no turno e retorna a resposta concatenada após esse
  intervalo (em segundos) sem novas mensagens.
Ambos preservam o comportamento legado quando não passados. A ativação dos
fixes fica a cargo do consumer (no nosso caso, `weni-cli-backend`).
## Compatibilidade
Bump **minor** (não major), pelas seguintes razões:
- Defaults dos parâmetros novos preservam o comportamento da `1.0.11`.
- API pública estendida com kwargs opcionais; nenhuma assinatura existente
  foi alterada de forma destrutiva.
- Os 17 testes legados que passavam continuam passando idênticos.
Quem está em `1.0.11`: zero impacto. Quem atualiza para `1.1.0` sem passar os
novos parâmetros: comportamento funcional idêntico.
## Notas
- CVE-2026-25645 em `requests 2.32.5` afeta apenas chamadores de
  `requests.utils.extract_zipped_paths`, que esta lib não usa. Correção requer
  derrubar suporte ao Python 3.9 (breaking change). Tratado fora do escopo
  deste PR — sugerido waiver no `pip-audit` (`--ignore-vuln CVE-2026-25645`)
  até abertura de PR de major bump.
